### PR TITLE
v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.0.1+1
 
+* NEW: Add two callbacks - ```onMove()``` and ```onLeave()```
+* NEW: Rename ```offsetWhenAppear``` -> ```startingOffset``` and make it open in the initialization constructor of ```ReorderableStaggeredGridViewItem```.
+* FIX: Do not recalculating coordinates when a new offset animation starts before the forst animation completed
+* FIX: Optimize repaintings when dragging has ended, but the order of the elemets has not changed
+
+## 0.0.1+1
+
 * Fix the generation of grid elements in the example.
 
 ## 0.0.1

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,10 +79,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -145,7 +145,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.1+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/lib/src/data/reorderable_staggered_grid_view_item.dart
+++ b/lib/src/data/reorderable_staggered_grid_view_item.dart
@@ -19,24 +19,26 @@ class ReorderableStaggeredGridViewItem<T> {
   /// The [curve] is a parametric animation easing curve, i.e. a mapping of the unit interval to the unit interval.
   final Curve curve;
 
-  /// The [offsetWhenAppear] is the widget's animation offset when the widget's content firstly has been built.
-  final Offset offsetWhenAppear;
+  /// The [startingOffset] is the widget's animation offset when the widget's content firstly has been built.
+  final Offset startingOffset;
 
   /// The [child] is the widget content of the item.
   final Widget child;
 
-  /// The [ReorderableStaggeredGridViewItem] is an object which describe its [child] constraints and behavior 
-  /// in [ReorderableStaggeredGridView].
+  /// The [ReorderableStaggeredGridViewItem] is an object which describe its [child] constraints and behavior
+  /// in grid view.
   ReorderableStaggeredGridViewItem({
     required this.data,
     required this.animationKey,
     required this.mainAxisCellCount,
     required this.crossAxisCellCount,
+    Offset? startingOffset,
     this.duration = const Duration(milliseconds: 300),
     this.curve = Curves.easeOut,
     required this.child,
-  }) : offsetWhenAppear = Offset(
-          1 / crossAxisCellCount,
-          (1 / mainAxisCellCount) * 100,
-        );
+  }) : startingOffset = startingOffset ??
+            Offset(
+              1 / crossAxisCellCount,
+              (1 / mainAxisCellCount) * 100,
+            );
 }

--- a/lib/src/reorderable_staggered_grid_view.dart
+++ b/lib/src/reorderable_staggered_grid_view.dart
@@ -318,12 +318,14 @@ class _ReorderableStaggeredGridViewState
                 return widget.onWillAcceptWithDetails!(details);
               }
 
-              // TODO The functionality below is still in development
+              /// =====-----=====-----=====-----=====-----=====-----=====
+              /// The functionality below is still in development
 
               // items.remove(draggingItem);
               // items.insert(index, draggingItem!);
 
               // setState(() {});
+              /// =====-----=====-----=====-----=====-----=====-----=====
 
               return true;
             },

--- a/lib/src/reorderable_staggered_grid_view.dart
+++ b/lib/src/reorderable_staggered_grid_view.dart
@@ -78,6 +78,13 @@ class ReorderableStaggeredGridView extends StatefulWidget {
   /// the tree (i.e. [State.mounted] is true).
   final void Function(DraggableDetails details)? onDragEnd;
 
+  /// The [onMove] called when draggable moving within drag target.
+  final void Function(DragTargetDetails details)? onMove;
+
+  /// The [onLeave] called when a given piece of data being dragged over this target leaves
+  /// the target.
+  final void Function(Object? data)? onLeave;
+
   /// The [onWillAcceptWithDetails] called to determine whether this widget is interested in receiving a given
   /// piece of data being dragged over this drag target.
   final bool Function(DragTargetDetails details)? onWillAcceptWithDetails;
@@ -123,6 +130,8 @@ class ReorderableStaggeredGridView extends StatefulWidget {
     this.onDragStarted,
     this.onDragUpdate,
     this.onDragEnd,
+    this.onMove,
+    this.onLeave,
     this.onWillAcceptWithDetails,
     this.onAcceptWithDetails,
     this.buildFeedbackWidget,
@@ -275,9 +284,10 @@ class _ReorderableStaggeredGridViewState
           }
 
           return ReorderableStaggeredGridItemWidget(
-            // Items
+            // Item
             item: item,
             isLastDraggedItem: identical(item, _lastDraggedItem),
+            index: index,
 
             // UI
             isDraggingEnabled: widget.enable,
@@ -308,6 +318,8 @@ class _ReorderableStaggeredGridViewState
               }
               widget.onDragEnd?.call(details);
             },
+            onLeave: widget.onLeave,
+            onMove: widget.onMove,
             scrollEndNotifier: _scrollEndNotifier,
 
             // Accepting

--- a/lib/src/reorderable_staggered_grid_view.dart
+++ b/lib/src/reorderable_staggered_grid_view.dart
@@ -142,6 +142,7 @@ class _ReorderableStaggeredGridViewState
   late final ScrollController _scrollController;
   late List<ReorderableStaggeredGridViewItem> _items;
 
+  // Autoscroll fields
   double _dragY = 0;
   bool _isAutoScrolling = false;
 
@@ -301,7 +302,10 @@ class _ReorderableStaggeredGridViewState
             },
             onDragEnd: (details) {
               _stopAutoScroll();
-              setState(() => _draggingItem = null);
+
+              if (_draggingItem != null) {
+                _draggingItem = null;
+              }
               widget.onDragEnd?.call(details);
             },
             scrollEndNotifier: _scrollEndNotifier,
@@ -329,6 +333,7 @@ class _ReorderableStaggeredGridViewState
               _items.remove(_draggingItem);
               _items.insert(index, _draggingItem!);
 
+              setState(() => _draggingItem = null);
               widget.onAcceptWithDetails?.call(details, index);
             },
           );

--- a/lib/src/reorderable_staggered_grid_view.dart
+++ b/lib/src/reorderable_staggered_grid_view.dart
@@ -276,7 +276,6 @@ class _ReorderableStaggeredGridViewState
           return ReorderableStaggeredGridItemWidget(
             // Items
             item: item,
-            draggingItem: _draggingItem,
             isLastDraggedItem: identical(item, _lastDraggedItem),
 
             // UI

--- a/lib/src/widgets/animated_grid_item_widget.dart
+++ b/lib/src/widgets/animated_grid_item_widget.dart
@@ -52,7 +52,7 @@ class _AnimatedGridItemWidgetState extends State<AnimatedGridItemWidget>
     );
 
     _animation = Tween<Offset>(
-      begin: widget.item?.offsetWhenAppear ??
+      begin: widget.item?.startingOffset ??
           Offset(
             0 * (1 / (widget.item?.crossAxisCellCount ?? 1)),
             100 * (1 / (widget.item?.mainAxisCellCount ?? 1)),
@@ -74,7 +74,7 @@ class _AnimatedGridItemWidgetState extends State<AnimatedGridItemWidget>
 
   @override
   void didUpdateWidget(covariant AnimatedGridItemWidget oldWidget) {
-    // Remove animation if objects this is the last dragged item
+    // Remove animation if this object is the last dragged item
     if (!widget.isLastDraggedItem) {
       startAnimation();
     } else {

--- a/lib/src/widgets/animated_grid_item_widget.dart
+++ b/lib/src/widgets/animated_grid_item_widget.dart
@@ -74,7 +74,7 @@ class _AnimatedGridItemWidgetState extends State<AnimatedGridItemWidget>
 
   @override
   void didUpdateWidget(covariant AnimatedGridItemWidget oldWidget) {
-    // Remove animation if this object is the last dragged item
+    // Remove animation if this object is a last dragged item
     if (!widget.isLastDraggedItem) {
       startAnimation();
     } else {

--- a/lib/src/widgets/animated_offset.dart
+++ b/lib/src/widgets/animated_offset.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 /// The [AnimatedOffset] is an [ImplicitlyAnimatedWidget] that can be shifted relating to [offset].
 class AnimatedOffset extends ImplicitlyAnimatedWidget {
-  /// The [offset] when there is a draggable widget above this drag target. 
+  /// The [offset] when there is a draggable widget above this drag target.
   final Offset offset;
 
   /// The [child] is the widget content of the item.

--- a/lib/src/widgets/reorderable_staggered_grid_item_widget.dart
+++ b/lib/src/widgets/reorderable_staggered_grid_item_widget.dart
@@ -8,6 +8,9 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
   /// The [item] which can be reordered or dragged.
   final ReorderableStaggeredGridViewItem item;
 
+  /// The [index] determines whether the position of the element in the grid has changed and whether animation needs to be started.
+  final int index;
+
   /// The [isLastDraggedItem] using to define that
   final bool isLastDraggedItem;
 
@@ -42,6 +45,13 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
   /// the tree (i.e. [State.mounted] is true).
   final void Function(DraggableDetails details) onDragEnd;
 
+  /// The [onMove] called when draggable moving within drag target.
+  final void Function(DragTargetDetails details)? onMove;
+
+  /// The [onLeave] called when a given piece of data being dragged over this target leaves
+  /// the target.
+  final void Function(Object? data)? onLeave;
+
   /// The [onWillAcceptWithDetails] called to determine whether this widget is interested in receiving a given
   /// piece of data being dragged over this drag target.
   final bool Function(DragTargetDetails details) onWillAcceptWithDetails;
@@ -73,6 +83,9 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
     required this.onAcceptWithDetails,
     required this.buildFeedbackWidget,
     required this.scrollEndNotifier,
+    required this.index,
+    required this.onMove,
+    required this.onLeave,
   });
 
   @override
@@ -82,6 +95,7 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
         // Not enabled dragging and drag target
         ? AnimatedGridItemWidget(
             key: item.animationKey,
+            index: index,
             scrollEndNotifier: scrollEndNotifier,
             isLastDraggedItem: isLastDraggedItem,
             item: item,
@@ -91,6 +105,7 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
         : DraggableGridItem(
             // Required key to start animation
             key: ObjectKey(item),
+            index: index,
 
             // Is long press need
             isLongPressDraggable: isLongPressDraggable,
@@ -99,6 +114,8 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
             onDragStarted: onDragStarted,
             onDragUpdate: onDragUpdate,
             onDragEnd: onDragEnd,
+            onLeave: onLeave,
+            onMove: onMove,
             scrollEndNotifier: scrollEndNotifier,
 
             // Offset when dragging over

--- a/lib/src/widgets/reorderable_staggered_grid_item_widget.dart
+++ b/lib/src/widgets/reorderable_staggered_grid_item_widget.dart
@@ -11,8 +11,6 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
   /// The [isLastDraggedItem] using to define that
   final bool isLastDraggedItem;
 
-  final ReorderableStaggeredGridViewItem? draggingItem;
-
   /// The [isLongPressDraggable] indicates does it take a long press to drag or not.
   final bool isLongPressDraggable;
 
@@ -64,7 +62,6 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
     super.key,
     required this.item,
     required this.isLastDraggedItem,
-    required this.draggingItem,
     required this.isDraggingEnabled,
     required this.isLongPressDraggable,
     required this.willAcceptOffsetDuration,
@@ -80,10 +77,6 @@ class ReorderableStaggeredGridItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (identical(item, draggingItem)) {
-      return const SizedBox.shrink();
-    }
-
     return !isDraggingEnabled
 
         // Not enabled dragging and drag target

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reorderable_staggered_grid_view
 description: A Flutter package for creating reorderable and staggered grid views.
-version: 0.0.1+1
+version: 0.1.0
 
 homepage: https://github.com/socrat-mniirs/reorderable_staggered_grid_view
 repository: https://github.com/socrat-mniirs/reorderable_staggered_grid_view


### PR DESCRIPTION
* NEW: Add two callbacks - ```onMove()``` and ```onLeave()```
* NEW: Rename ```offsetWhenAppear``` -> ```startingOffset``` and make it open in the initialization constructor of ```ReorderableStaggeredGridViewItem```.
* FIX: Do not recalculating coordinates when a new offset animation starts before the forst animation completed
* FIX: Optimize repaintings when dragging has ended, but the order of the elemets has not changed