### PR TITLE
v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* FIX: Fixed the error of dynamically changing crossAxisCount by changing the grid key (the scenario is a bypass of the well-known bug in the StaggeredGridView package, in which the positions of elements are incorrectly recalculated or not redrawn).
+
 ## 0.1.0+1
 
 * Format dart code

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,6 +24,9 @@ class _ReorderableStaggeredGridViewExampleState
   bool enableLongPress = false;
   bool enableDragging = true;
 
+  UniqueKey? _gridKey;
+  int? _lastCrossAxisCount;
+
   // Add item
   void _addNewItem() {
     final newItem = Constants._generateItem(
@@ -184,18 +187,28 @@ class _ReorderableStaggeredGridViewExampleState
 
         // Body
         body: LayoutBuilder(
-          builder: (context, constraints) => ReorderableStaggeredGridView(
-            padding: EdgeInsets.all(20),
-            enable: enableDragging,
-            crossAxisCount: Constants.calculateCrossAxisCount(
+          builder: (context, constraints) {
+            final crossAxisCount = Constants.calculateCrossAxisCount(
               constraints.maxWidth,
-            ),
-            mainAxisSpacing: Constants.spacing,
-            crossAxisSpacing: Constants.spacing,
-            isLongPressDraggable: enableLongPress,
-            nonDraggableWidgetsKeys: [Constants._widgetKeys[0]!],
-            items: items,
-          ),
+            );
+
+            if (_lastCrossAxisCount != crossAxisCount) {
+              _lastCrossAxisCount = crossAxisCount;
+              _gridKey = UniqueKey();
+            }
+
+            return ReorderableStaggeredGridView(
+              key: _gridKey,
+              padding: EdgeInsets.all(20),
+              enable: enableDragging,
+              crossAxisCount: crossAxisCount,
+              mainAxisSpacing: Constants.spacing,
+              crossAxisSpacing: Constants.spacing,
+              isLongPressDraggable: enableLongPress,
+              nonDraggableWidgetsKeys: [Constants._widgetKeys[0]!],
+              items: items,
+            );
+          },
         ),
       ),
     );

--- a/lib/src/widgets/animated_grid_item_widget.dart
+++ b/lib/src/widgets/animated_grid_item_widget.dart
@@ -104,10 +104,16 @@ class _AnimatedGridItemWidgetState extends State<AnimatedGridItemWidget>
 
   // Saving the current position of the grid element
   void _capturePosition() {
-    final renderBox = context.findRenderObject() as RenderBox?;
-    if (renderBox != null) {
-      _position = renderBox.localToGlobal(Offset.zero);
-    }
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) {
+        if (mounted) {
+          final renderBox = context.findRenderObject() as RenderBox?;
+          if (renderBox != null) {
+            _position = renderBox.localToGlobal(Offset.zero);
+          }
+        }
+      },
+    );
   }
 
   // Animating the grid element to a new position and saving the current position after that

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reorderable_staggered_grid_view
 description: A Flutter package for creating reorderable and staggered grid views.
-version: 0.1.0+1
+version: 0.1.1
 
 homepage: https://github.com/socrat-mniirs/reorderable_staggered_grid_view
 repository: https://github.com/socrat-mniirs/reorderable_staggered_grid_view


### PR DESCRIPTION
## 0.1.1

* FIX: Fixed the error of dynamically changing crossAxisCount by changing the grid key (the scenario is a bypass of the well-known bug in the StaggeredGridView package, in which the positions of elements are incorrectly recalculated or not redrawn).